### PR TITLE
Revert "🐛 property parent remove for account (error in logs)"

### DIFF
--- a/theme/potentiel/account/theme.properties
+++ b/theme/potentiel/account/theme.properties
@@ -1,4 +1,5 @@
 locales=en
+parent=keycloak
 import=common/potentiel
 common=common/potentiel
 potentielUrl=${env.POTENTIEL_BASE_URL}


### PR DESCRIPTION
Reverts MTES-MCT/potentiel-keycloak#21